### PR TITLE
Add hcom to Agent Orchestration & CLI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Modified versions of Gemini CLI with enhanced features or alternative model supp
 ## Agent Orchestration & CLI Tools
 
 - [squads-cli](https://github.com/agents-squads/squads-cli) - Open source CLI for AI agent coordination that organizes agents into domain-aligned squads with persistent memory, goal tracking, and Git-native state.  Works with Gemini CLI.
+- [hcom](https://github.com/aannoo/hcom) - Let AI agents message, watch, and spawn each other across terminals. First-class Gemini CLI support with hooks integration and PTY wrapper. Also works with Claude Code, Codex, and OpenCode.
 
 ## Fun
 


### PR DESCRIPTION
Adds hcom to the Agent Orchestration & CLI Tools section.

hcom lets AI agents message, watch, and spawn each other across terminals. First-class Gemini CLI support with hooks integration and PTY wrapper. Also works with Claude Code, Codex, and OpenCode.

https://github.com/aannoo/hcom