### PR TITLE
Add BGPT MCP — scientific paper search

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Model Context Protocol servers that enable Gemini CLI integration with other AI 
 - [gemini-cli-mcp](https://github.com/InfolabAI/gemini-cli-mcp) - Tool that enables using Gemini AI as an MCP server within Claude Code with large file analysis and token savings.
 - [gemini-mcp](https://github.com/neriousy/gemini-mcp) - A simple MCP server for using the Gemini CLI.
 - [gemini-cli-mcp](https://github.com/0xmountaintop/gemini-cli-mcp) - A Model Context Protocol (MCP) wrapper for Google Gemini CLI that enables AI development tools to interact with Gemini.
+- [BGPT MCP](https://github.com/connerlambden/bgpt-mcp) - Search scientific papers and get structured experimental data (methods, results, sample sizes, quality scores) from full-text studies. Remote MCP server with free tier.
 
 ## Neovim Plugins
 


### PR DESCRIPTION
Adds [BGPT MCP](https://github.com/connerlambden/bgpt-mcp) to the MCP Servers section.

BGPT is a remote MCP server that searches scientific papers and returns structured experimental data from full-text studies (methods, results, sample sizes, quality scores). Works with any MCP client including Gemini CLI via `npx mcp-remote https://bgpt.pro/mcp/sse`. Free tier with 50 searches, no API key needed.


Made with [Cursor](https://cursor.com)