### PR TITLE
add: add Xquik MCP to MCP Servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Model Context Protocol servers that enable Gemini CLI integration with other AI 
 - [gemini-mcp](https://github.com/neriousy/gemini-mcp) - A simple MCP server for using the Gemini CLI.
 - [gemini-cli-mcp](https://github.com/0xmountaintop/gemini-cli-mcp) - A Model Context Protocol (MCP) wrapper for Google Gemini CLI that enables AI development tools to interact with Gemini.
 - [Xquik MCP](https://github.com/Xquik-dev/x-twitter-scraper) - X/Twitter data MCP server with 76 REST API endpoints, 20 extraction tools, account monitoring, and giveaway draws. Works with any MCP client including Gemini CLI.
+
 ## Neovim Plugins
 
 Plugins that bring Gemini CLI's AI capabilities directly into the Neovim editor.


### PR DESCRIPTION
Adds [Xquik MCP](https://github.com/Xquik-dev/x-twitter-scraper) to the MCP Servers section.

X/Twitter data MCP server with 76 REST API endpoints, 20 extraction tools, account monitoring, and giveaway draws. Works with any MCP client including Gemini CLI.

**Disclosure**: I am the developer of Xquik.