### PR TITLE
Add wolfpack: mobile & desktop command center for AI coding agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Modified versions of Gemini CLI with enhanced features or alternative model supp
 - [hcom](https://github.com/aannoo/hcom) - Let AI agents message, watch, and spawn each other across terminals. First-class Gemini CLI support with hooks integration and PTY wrapper. Also works with Claude Code, Codex, and OpenCode.
 - [squads-cli](https://github.com/agents-squads/squads-cli) - Open source CLI for AI agent coordination that organizes agents into domain-aligned squads with persistent memory, goal tracking, and Git-native state.  Works with Gemini CLI.
 
+- [wolfpack](https://github.com/almogdepaz/wolfpack) - Mobile & desktop command center for controlling AI coding agents (Claude, Codex, Gemini) across machines from your phone. Secured by Tailscale. Self-hosted.
 ## Fun
 
 Playful and creative tools inspired by or that add personality to Gemini CLI.


### PR DESCRIPTION
**GitHub:** https://github.com/almogdepaz/wolfpack

Wolfpack is a self-hosted mobile & desktop command center for AI coding agents. It lets you control Claude, Codex, and **Gemini** tmux sessions across machines from your phone — secured by Tailscale with no open ports.

Added to **Agent Orchestration & CLI Tools** section — fits alongside hcom and squads-cli.