### PR TITLE
Add Untether — Telegram bridge with Gemini CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ Modified versions of Gemini CLI with enhanced features or alternative model supp
 - [squads-cli](https://github.com/agents-squads/squads-cli) - Open source CLI for AI agent coordination that organizes agents into domain-aligned squads with persistent memory, goal tracking, and Git-native state.  Works with Gemini CLI.
 
 - [wolfpack](https://github.com/almogdepaz/wolfpack) - Mobile & desktop command center for controlling AI coding agents (Claude, Codex, Gemini) across machines from your phone. Secured by Tailscale. Self-hosted.
+
+- [Untether](https://github.com/littlebearapps/untether) - Telegram bridge for Gemini CLI (and 5 other agents). Send tasks by voice, stream progress, configure approval mode (read-only/edit files/full access) via inline buttons. Self-hosted, MIT licensed.
+
 ## Fun
 
 Playful and creative tools inspired by or that add personality to Gemini CLI.


### PR DESCRIPTION
Adds [Untether](https://github.com/littlebearapps/untether) to the Agent Orchestration & CLI Tools section.

Untether connects Gemini CLI to a Telegram bot for remote task management.

Gemini-specific features:
- Approval mode control via `/config` — read-only, edit files, or full access
- Model override via `/model set <name>`
- Voice note transcription for hands-free task input
- Progress streaming with tool call details
- Session resume
- Cost tracking (token counts)

Also supports Claude Code, Codex, OpenCode, Pi, and Amp — switch engines per chat.

MIT licensed, `uv tool install untether`.