### PR TITLE
Add Termly — free native mobile app for Gemini CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Alternative user interfaces and frontends for interacting with Gemini CLI beyond
 
 - [Gemini CLI Desktop](https://github.com/Piebald-AI/gemini-CLI-desktop) - Beautiful desktop and web UI that makes Gemini CLI accessible to non-terminal/mobile users while preserving all its powerful features.
 - [AionUi](https://github.com/iOfficeAI/AionUi) - Free, local, open-source GUI app for Gemini CLI — Better Chat UI, File Management, AI image editing, multi-agent support, multi-LLMs & apikey polling, code diff view & more.
+- [Termly](https://termly.dev/) - Free native iOS and Android app to monitor and control Gemini CLI (and other CLI AI assistants) remotely. Zero-knowledge E2E encryption, pairs in under 60 seconds via QR code. No subscriptions, no usage limits.
 
 ## Forks
 


### PR DESCRIPTION
## Summary

Adds [Termly](https://termly.dev/) to the **Interfaces** section.

Termly is a free native iOS and Android app that lets you monitor and control Gemini CLI (and other CLI AI assistants) remotely from your phone. It connects via a zero-knowledge WebSocket relay — the server never decrypts your data. Pairs in under 60 seconds via QR code. No subscriptions, no usage limits.

Fits the Interfaces section as an alternative UI for interacting with Gemini CLI beyond the terminal.