### PR TITLE
Add Bernstein to Agent Orchestration & CLI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Modified versions of Gemini CLI with enhanced features or alternative model supp
 - [squads-cli](https://github.com/agents-squads/squads-cli) - Open source CLI for AI agent coordination that organizes agents into domain-aligned squads with persistent memory, goal tracking, and Git-native state.  Works with Gemini CLI.
 - [wolfpack](https://github.com/almogdepaz/wolfpack) - Mobile & desktop command center for controlling AI coding agents (Claude, Codex, Gemini) across machines from your phone. Secured by Tailscale. Self-hosted.
 - [Untether](https://github.com/littlebearapps/untether) - Telegram bridge for Gemini CLI (and 5 other agents). Send tasks by voice, stream progress, configure approval mode (read-only/edit files/full access) via inline buttons. Self-hosted, MIT licensed.
+- [Bernstein](https://github.com/chernistry/bernstein) - Multi-agent orchestrator that coordinates Gemini CLI alongside Claude Code and Codex CLI — parallel task execution with test-driven verification.
 
 ## Commands & Extensions
 


### PR DESCRIPTION
Adds [Bernstein](https://github.com/chernistry/bernstein) to the **Agent Orchestration & CLI Tools** section.

Bernstein is a multi-agent orchestrator that coordinates Gemini CLI alongside Claude Code and Codex CLI, enabling parallel task execution with test-driven verification.