### PR TITLE
Add ru-text: Russian text quality extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Custom commands and extensions that add new capabilities to Gemini CLI.
 - [GeminiCLI_Slash_Listen](https://github.com/automateyournetwork/GeminiCLI_Slash_Listen) - Innovative `/listen` command enabling remote Gemini CLI access through Slack, perfect for collaborative coding and remote assistance scenarios.
 - [gemini-cli-custom-slash-commands](https://github.com/amitkmaraj/gemini-cli-custom-slash-commands) - Curated collection of productivity-boosting custom slash commands that extend Gemini CLI with specialized workflows and shortcuts.
 - [gemini-flow](https://github.com/clduab11/gemini-flow) - Transforms Gemini CLI into an autonomous AI development team using proven Claude-Flow patterns, enabling complex multi-agent workflows.
+- [**ru-text**](https://github.com/talkstream/ru-text) - Russian text quality — ~1,040 rules for typography, info-style, editorial, UX writing, business correspondence.
 
 ## Fun
 


### PR DESCRIPTION
## Summary

- Adds [ru-text](https://github.com/talkstream/ru-text) to the **Commands & Extensions** section.
- ~1,040 rules covering typography, info-style, editorial, UX writing, and business correspondence for Russian-language text quality.
- Works as a Gemini CLI extension (also supports Claude Code, Cursor, Windsurf, Copilot).

## Test plan

- [x] Entry placed at the bottom of the Commands & Extensions section per contributing guidelines.
- [x] Format matches `[**Project Name**](URL) - Description` as specified in CONTRIBUTING.md.
- [x] Link resolves to the correct repository.