### PR TITLE
Add brooks-lint extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Custom commands and extensions that add new capabilities to Gemini CLI.
 
 - [Task Monitor](https://github.com/davidwiet/task-monitor) - Prevents agent loops via message tracking and plays auditory notifications for long tasks or out-of-focus prompts.
 - [ATXP](https://github.com/atxp-dev/atxp) - Give your Gemini CLI agent a wallet, email address, phone number, and 100+ paid MCP tools (web search, image gen, SMS, voice, LLM gateway). Self-register with `gemini extensions install https://github.com/atxp-dev/atxp` — no human login required, $5 free credits included.
+- [brooks-lint](https://github.com/hyhmrright/brooks-lint) - AI code reviews grounded in six classic engineering books. Diagnoses decay risks with structured findings (Symptom → Source → Consequence → Remedy).
 - [gemini-notifier](https://github.com/thoreinstein/gemini-notifier) - A Gemini extension to send native system-level notifications when Gemini requests permissions.
 - [Pickle Rick](http://github.com/galz10/pickle-rick-extension) - This extension transforms the Gemini CLI into "Pickle Rick," a hyper-intelligent, arrogant, yet extremely competent engineering persona. It enforces a rigid, iterative software development lifecycle through continuous AI agent loops.
 - [gemini-beads](https://github.com/thoreinstein/gemini-beads) - Git-backed persistent memory and task management for Gemini CLI.


### PR DESCRIPTION
Add [brooks-lint](https://github.com/hyhmrright/brooks-lint) to the Commands & Extensions section.

**brooks-lint** is a Gemini CLI extension (and Claude Code plugin) that performs AI code reviews grounded in six classic software engineering books (*The Mythical Man-Month*, *Code Complete*, *Refactoring*, *A Philosophy of Software Design*, *Clean Code*, *Working Effectively with Legacy Code*). It diagnoses decay risks across four review modes (PR Review, Architecture Audit, Tech Debt Assessment, Test Quality Review) with structured findings: Symptom → Source → Consequence → Remedy.

Install via `gemini extensions install https://github.com/hyhmrright/brooks-lint`.