### PR TITLE
Add TokRepo skill and MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Custom commands and extensions that add new capabilities to Gemini CLI.
 - [gemini-cli-custom-slash-commands](https://github.com/amitkmaraj/gemini-cli-custom-slash-commands) - Curated collection of productivity-boosting custom slash commands that extend Gemini CLI with specialized workflows and shortcuts.
 - [gemini-flow](https://github.com/clduab11/gemini-flow) - Transforms Gemini CLI into an autonomous AI development team using proven Claude-Flow patterns, enabling complex multi-agent workflows.
 - [**ru-text**](https://github.com/talkstream/ru-text) - Russian text quality — ~1,040 rules for typography, info-style, editorial, UX writing, business correspondence.
+- [TokRepo Search Skill](https://github.com/henu-wang/tokrepo-search-skill) - Cross-platform TokRepo skill with Gemini extension files for finding and installing AI assets such as prompts, MCP configs, workflows, and reusable skills.
 
 ## Fun
 
@@ -197,6 +198,7 @@ Model Context Protocol servers that enable Gemini CLI integration with other AI 
 - [gemini-mcp](https://github.com/neriousy/gemini-mcp) - A simple MCP server for using the Gemini CLI.
 - [gemini-cli-mcp](https://github.com/0xmountaintop/gemini-cli-mcp) - A Model Context Protocol (MCP) wrapper for Google Gemini CLI that enables AI development tools to interact with Gemini.
 - [Xquik MCP](https://github.com/Xquik-dev/x-twitter-scraper) - X/Twitter data MCP server with 76 REST API endpoints, 20 extraction tools, account monitoring, and giveaway draws. Works with any MCP client including Gemini CLI.
+- [TokRepo MCP Server](https://github.com/henu-wang/tokrepo-mcp-server) - Search and install AI skills, prompts, MCP configs, and workflows from TokRepo from Gemini CLI and other MCP clients.
 
 ## Neovim Plugins
 


### PR DESCRIPTION
Adds two TokRepo entry points that fit existing sections:

- `TokRepo Search Skill` under `Commands & Extensions`
- `TokRepo MCP Server` under `MCP Servers`

Why it fits:
- TokRepo ships Gemini extension files in the skill repo
- the MCP server works directly with Gemini CLI via MCP
- both help Gemini CLI users discover and install reusable AI assets
