### PR TITLE
Add toprank to Non-Gemini CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ Educational materials and documentation to try out Gemini CLI if you're new.
 Cool projects that don't pertain to Gemini CLI specifically but do utilitize Gemini.
 
 - [Git-Alchemist](https://github.com/abduznik/Git-Alchemist) - A unified AI-powered CLI tool for automating GitHub repository management (issues, PRs, topics, profiles) powered by Gemini 3 and Gemma 3.
+- [toprank](https://github.com/nowork-studio/toprank) - Claude Code plugin for SEO and Google Ads that includes a Gemini cross-model review skill. Uses Gemini for second-opinion reviews on Google Ads campaigns, SEO metadata, and schema markup — leveraging Gemini's native Google ecosystem knowledge for higher-quality decisions than Claude alone. MIT, 107 stars.
 
 ## Contributing
 


### PR DESCRIPTION
Adds **toprank** to the Non-Gemini CLI section (projects that don't pertain to Gemini CLI specifically but do utilize Gemini).

toprank is a Claude Code plugin for SEO and Google Ads that includes a **gemini cross-model review skill**. The skill uses Gemini specifically because it has native knowledge of Google's ecosystem (Search Console, Ads API, PageSpeed Insights, schema.org) — making it the ideal second-opinion model for reviewing:

- Google Ads campaign changes before they ship
- SEO metadata and JSON-LD schema markup
- E-E-A-T content decisions for Google search

It's 3 modes: `review` (pass/fail gate), `challenge` (adversarial stress-test), `consult` (open Q&A with session continuity).

## Traction
- **107 GitHub stars, 14 forks**
- MIT licensed, actively maintained

- Source: https://github.com/nowork-studio/toprank