### PR TITLE
Add OpenAccountants to Custom Slash Commands & Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Custom commands and extensions that add new capabilities to Gemini CLI.
 - [**ru-text**](https://github.com/talkstream/ru-text) - Russian text quality — ~1,040 rules for typography, info-style, editorial, UX writing, business correspondence.
 - [TokRepo Search Skill](https://github.com/henu-wang/tokrepo-search-skill) - Cross-platform TokRepo skill with Gemini extension files for finding and installing AI assets such as prompts, MCP configs, workflows, and reusable skills.
 - [dRPC Agent Skills](https://github.com/drpcorg/drpc-agent-skills) - Query blockchain RPCs from Gemini CLI. Fetch balances, read contracts, and check gas prices via dRPC.
+- [OpenAccountants](https://github.com/openaccountants/openaccountants) - 371 tax classification skills across 134 countries. Classify bank statement transactions into VAT/GST, income tax, and social contribution categories with conservative defaults.
 
 ## Fun
 


### PR DESCRIPTION
## Summary

- Adds [OpenAccountants](https://github.com/openaccountants/openaccountants) to the **Custom Slash Commands & Skills** section
- 371 tax classification skills across 134 countries for VAT/GST, income tax, and social contributions
- Bank statement classifier with conservative defaults — compatible with Gemini CLI agent skills

Made with [Cursor](https://cursor.com)