### PR TITLE
Add Emdash Skills to Frameworks section

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,8 @@ Frameworks for building AI-powered development workflows with Gemini CLI.
 - [gemini-code-flow](https://github.com/Theopsguide/gemini-code-flow) - Enterprise-grade orchestration framework that coordinates multiple Gemini CLI instances for complex development tasks, based on battle-tested Claude Code Flow patterns.
 - [gemini-cli-commands-demo](https://github.com/pauldatta/gemini-cli-commands-demo) - A proof-of-concept demonstrating a sub-agent orchestration system built within the Gemini CLI.
 
+- [Emdash Skills](https://github.com/megabytespace/claude-skills) - 14-category autonomous product-building OS with 18 specialized agents. Turns one-line prompts into deployed products. Includes GEMINI.md compatibility for cross-tool portability. Skills cover architecture, planning, quality, brand, media, observability, and deployment on Cloudflare Workers.
+
 ## Documentation & Examples
 
 Educational materials and documentation to try out Gemini CLI if you're new.

--- a/README.md
+++ b/README.md
@@ -224,7 +224,6 @@ Frameworks for building AI-powered development workflows with Gemini CLI.
 - [GACUA](https://github.com/openmule/gacua) - The world's first out-of-the-box computer use agent powered by Gemini CLI @openmule.
 - [gemini-code-flow](https://github.com/Theopsguide/gemini-code-flow) - Enterprise-grade orchestration framework that coordinates multiple Gemini CLI instances for complex development tasks, based on battle-tested Claude Code Flow patterns.
 - [gemini-cli-commands-demo](https://github.com/pauldatta/gemini-cli-commands-demo) - A proof-of-concept demonstrating a sub-agent orchestration system built within the Gemini CLI.
-
 - [Emdash Skills](https://github.com/megabytespace/claude-skills) - 14-category autonomous product-building OS with 18 specialized agents. Turns one-line prompts into deployed products. Includes GEMINI.md compatibility for cross-tool portability. Skills cover architecture, planning, quality, brand, media, observability, and deployment on Cloudflare Workers.
 
 ## Documentation & Examples


### PR DESCRIPTION
## Summary
- Adds [Emdash Skills](https://github.com/megabytespace/claude-skills) to the Frameworks section
- 14-category autonomous product-building OS with 18 specialized agents
- Includes GEMINI.md compatibility for cross-tool portability with Gemini CLI
- Skills cover architecture, planning, quality, brand, media, observability, and deployment on Cloudflare Workers

## Entry format
Matches existing format: `- [Name](url) - Description.`