### PR TITLE
Add prompt-to-asset (MCP server) and unslop (dev tool)

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Tools that enhance your development workflow when using Gemini CLI.
 - [codebase-recon](https://github.com/yujiachen-y/codebase-recon-skill) - AI agent skill that analyzes git history to reveal codebase hotspots, bug magnets, bus factor risks, and development momentum before reading any code. Works with Gemini CLI, Claude Code, Cursor, and 20+ other coding agents.
 - [Gemini CLI Logs Prettifier](https://github.com/Manamama/Puzzles_for_AIs/tree/main/code/Gemini%20CLI%20logs%20prettifier) - Renders the logs human readable (prettifies them) and browsable as interlinked HTML, with thoughtful explanations and clickable links.
 - [Signum](https://github.com/heurema/signum) - Evidence-driven development pipeline that uses Gemini CLI as one of three independent reviewers in a multi-model code audit panel (alongside Claude and Codex).
+- [unslop](https://github.com/MohamedAbdallah-14/unslop) - CLI and MCP server that removes AI writing patterns from text: tricolons, em-dash overuse, hedging stacks, sycophancy openers, and overused vocabulary. Works with any MCP client including Gemini CLI. Five intensity levels and a lint-only audit mode. Useful for cleaning commit messages, PR descriptions, and documentation.
 
 ## Browser Extensions
 
@@ -207,6 +208,7 @@ Model Context Protocol servers that enable Gemini CLI integration with other AI 
 - [gemini-cli-mcp](https://github.com/0xmountaintop/gemini-cli-mcp) - A Model Context Protocol (MCP) wrapper for Google Gemini CLI that enables AI development tools to interact with Gemini.
 - [Xquik MCP](https://github.com/Xquik-dev/x-twitter-scraper) - X/Twitter data MCP server with 76 REST API endpoints, 20 extraction tools, account monitoring, and giveaway draws. Works with any MCP client including Gemini CLI.
 - [TokRepo MCP Server](https://github.com/henu-wang/tokrepo-mcp-server) - Search and install AI skills, prompts, MCP configs, and workflows from TokRepo from Gemini CLI and other MCP clients.
+- [prompt-to-asset](https://github.com/MohamedAbdallah-14/prompt-to-asset) - MCP server that generates production-ready visual assets (app icons, favicons, OG images, logos, wordmarks) by routing requests across 30+ image generation models. Zero API key required for first run via Pollinations and Stable Horde free tiers. Works with any MCP client including Gemini CLI.
 
 ## Neovim Plugins
 


### PR DESCRIPTION
Adds two cross-platform MCP tools to the appropriate sections.

**prompt-to-asset** (MCP Servers)
An MCP server for generating production-ready visual assets — app icons, favicons, OG images, logos, wordmarks — by routing requests across 30+ image generation models. Validates output for WCAG contrast. Zero API key required for first run via Pollinations and Stable Horde free tiers. Works with any MCP client including Gemini CLI.

- GitHub: https://github.com/MohamedAbdallah-14/prompt-to-asset
- Npm: `npx prompt-to-asset`
- MIT licensed

**unslop** (Development Tools & Utilities)
CLI and MCP server that removes AI writing patterns from text. Detects tricolons, em-dash overuse, hedging stacks, sycophancy openers, and overused vocabulary. Works with any MCP client including Gemini CLI. Five intensity levels and a lint-only audit mode. Useful for cleaning commit messages, PR descriptions, and documentation.

- GitHub: https://github.com/MohamedAbdallah-14/unslop
- Npm: `npx unslop` / pip: `pip install unslop`
- MIT licensed
