### PR TITLE
Add agentwatch to Development Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Tools that enhance your development workflow when using Gemini CLI.
 - [codebase-recon](https://github.com/yujiachen-y/codebase-recon-skill) - AI agent skill that analyzes git history to reveal codebase hotspots, bug magnets, bus factor risks, and development momentum before reading any code. Works with Gemini CLI, Claude Code, Cursor, and 20+ other coding agents.
 - [Gemini CLI Logs Prettifier](https://github.com/Manamama/Puzzles_for_AIs/tree/main/code/Gemini%20CLI%20logs%20prettifier) - Renders the logs human readable (prettifies them) and browsable as interlinked HTML, with thoughtful explanations and clickable links.
 - [Signum](https://github.com/heurema/signum) - Evidence-driven development pipeline that uses Gemini CLI as one of three independent reviewers in a multi-model code audit panel (alongside Claude and Codex).
+- [agentwatch](https://github.com/mishanefedov/agentwatch) - Local-only TUI + web dashboard that tails Gemini CLI sessions alongside Claude Code, Codex, Cursor, Hermes, and OpenClaw on one unified timeline. Parses tokens, tools, and per-turn cost from each Gemini CLI session (gemini-2.5-pro / flash rates), plus context compaction visualizer, MAD z-score anomaly detection, MCP server mode, and OpenTelemetry exporter. No cloud, no telemetry. macOS + Linux. MIT.
 
 ## Browser Extensions
 


### PR DESCRIPTION
## Summary

agentwatch is a local-only TUI + web dashboard that tails Gemini CLI sessions alongside other coding agents (Claude Code, Codex, Cursor, Hermes, OpenClaw) on one unified timeline.

## Gemini CLI–specific coverage
- Parses each `~/.gemini/tmp/<hash>/logs.json` session into structured events
- Extracts token usage from every `gemini` message (input / output / cached)
- Decomposes `toolCalls[]` into typed events: `file_read`, `file_write`, `shell_exec`, `tool_call`, with inline `functionResponse` output
- Captures the model from `session_meta` and applies gemini-2.5-pro / gemini-2.5-flash cost rates per turn
- Reads `~/.gemini/settings.json` for the permission viewer (auth, tools allow/block, trusted folders)

Plus shared features: context compaction visualizer, MAD z-score anomaly detection on cost / duration / tokens, period-1-to-4 stuck-loop detector, hybrid semantic search, MCP server mode, OpenTelemetry exporter (`gen_ai.*` semantic conventions), session export to markdown / JSON.

## Why it fits this list
Per CONTRIBUTING: "Entries should be related to Gemini CLI (e.g. use it, build something on top of it, upgrade it in some way)" — agentwatch reads Gemini CLI's session logs and builds observability on top of them. Appended to the bottom of **Development Tools & Utilities** as required.

No cloud, no telemetry. macOS + Linux. MIT.

Repo: https://github.com/mishanefedov/agentwatch
npm: https://www.npmjs.com/package/@misha_misha/agentwatch