### PR TITLE
Add ToutKit to Agent Orchestration & CLI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Modified versions of Gemini CLI with enhanced features or alternative model supp
 - [Untether](https://github.com/littlebearapps/untether) - Telegram bridge for Gemini CLI (and 5 other agents). Send tasks by voice, stream progress, configure approval mode (read-only/edit files/full access) via inline buttons. Self-hosted, MIT licensed.
 - [Parallel Code](https://github.com/johannesjo/parallel-code) - Desktop app for orchestrating multiple AI coding agents (Claude Code, Codex CLI, Gemini CLI) simultaneously in isolated git worktrees.
 - [clideck](https://github.com/rustykuntz/clideck) - WhatsApp-like dashboard for managing multiple AI coding agents (including Gemini CLI) in one browser window. Live status, session resume, autopilot that routes work between agents while afk, mobile remote to check in from a phone.
+- [ToutKit](https://github.com/toutkit/toutkit) - Desktop notebook with a built-in terminal that runs Gemini CLI alongside Claude Code and Codex; an in-app webview renders whatever the agent writes inline, and each note is a self-contained folder with its own SQLite, files, and scripts. Local-first, Electron, AGPL-3.0.
 
 ## Commands & Extensions
 


### PR DESCRIPTION
Adds [**ToutKit**](https://github.com/toutkit/toutkit) to **Agent Orchestration & CLI Tools**.

ToutKit is a local-first desktop notebook that pairs a sidebar of notes with a built-in terminal for Gemini CLI (alongside Claude Code and Codex CLI) and an in-app webview that renders whatever the agent writes inline — so answers come back as interactive HTML pages instead of walls of text. Each note is a self-contained folder with its own SQLite, key/value store, attached files, and scripts, so a note can grow from a static page into a sortable table, dashboard, or research tool without leaving your filesystem.

Section fit: closest precedents in the section are Parallel Code, wolfpack, and clideck — multi-CLI desktop apps that coordinate Gemini CLI alongside other coding agents.

- Repo: https://github.com/toutkit/toutkit
- License: AGPL-3.0
- Stack: Electron / JavaScript
- Cross-platform: macOS, Windows, Linux