### PR TITLE
Add gemini-discord to Commands & Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,6 @@ Custom commands and extensions that add new capabilities to Gemini CLI.
 - [OpenAccountants](https://github.com/openaccountants/openaccountants) - 371 tax classification skills across 134 countries. Classify bank statement transactions into VAT/GST, income tax, and social contribution categories with conservative defaults.
 - [gemini-discord](https://github.com/Yamato-main/gemini-discord) - Turn your local Gemini CLI agent into an always-on Discord presence that also doubles as your personal server admin.
 
-
 ## Fun
 
 Playful and creative tools inspired by or that add personality to Gemini CLI.

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Custom commands and extensions that add new capabilities to Gemini CLI.
 - [TokRepo Search Skill](https://github.com/henu-wang/tokrepo-search-skill) - Cross-platform TokRepo skill with Gemini extension files for finding and installing AI assets such as prompts, MCP configs, workflows, and reusable skills.
 - [dRPC Agent Skills](https://github.com/drpcorg/drpc-agent-skills) - Query blockchain RPCs from Gemini CLI. Fetch balances, read contracts, and check gas prices via dRPC.
 - [OpenAccountants](https://github.com/openaccountants/openaccountants) - 371 tax classification skills across 134 countries. Classify bank statement transactions into VAT/GST, income tax, and social contribution categories with conservative defaults.
-- [gemini-discord](https://github.com/Yamato-main/gemini-discord) - Turn your local Gemini CLI into an always-on Discord agent and server admin.
+- [gemini-discord](https://github.com/Yamato-main/gemini-discord) - Turn your local Gemini CLI agent into an always-on Discord presence that also doubles as your personal server admin.
 
 
 ## Fun

--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ Custom commands and extensions that add new capabilities to Gemini CLI.
 - [TokRepo Search Skill](https://github.com/henu-wang/tokrepo-search-skill) - Cross-platform TokRepo skill with Gemini extension files for finding and installing AI assets such as prompts, MCP configs, workflows, and reusable skills.
 - [dRPC Agent Skills](https://github.com/drpcorg/drpc-agent-skills) - Query blockchain RPCs from Gemini CLI. Fetch balances, read contracts, and check gas prices via dRPC.
 - [OpenAccountants](https://github.com/openaccountants/openaccountants) - 371 tax classification skills across 134 countries. Classify bank statement transactions into VAT/GST, income tax, and social contribution categories with conservative defaults.
+- [gemini-discord](https://github.com/Yamato-main/gemini-discord) - Turn your local Gemini CLI into an always-on Discord agent and server admin.
+
 
 ## Fun
 


### PR DESCRIPTION
Added gemini-discord, a Gemini CLI extension that turns your local agent into an always-on Discord presence that also doubles as your personal server admin.