### PR TITLE
Add Ivy Tendril to Agent Orchestration & CLI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Modified versions of Gemini CLI with enhanced features or alternative model supp
 - [Parallel Code](https://github.com/johannesjo/parallel-code) - Desktop app for orchestrating multiple AI coding agents (Claude Code, Codex CLI, Gemini CLI) simultaneously in isolated git worktrees.
 - [clideck](https://github.com/rustykuntz/clideck) - WhatsApp-like dashboard for managing multiple AI coding agents (including Gemini CLI) in one browser window. Live status, session resume, autopilot that routes work between agents while afk, mobile remote to check in from a phone.
 - [ToutKit](https://github.com/toutkit/toutkit) - Desktop notebook with a built-in terminal that runs Gemini CLI alongside Claude Code and Codex; an in-app webview renders whatever the agent writes inline, and each note is a self-contained folder with its own SQLite, files, and scripts. Local-first, Electron, AGPL-3.0.
+- [Ivy Tendril](https://github.com/Ivy-Interactive/Ivy-Tendril) - Open-source desktop app that orchestrates Gemini CLI alongside Claude Code, Codex, and Copilot through a plan-based lifecycle with verification gates, self-improving memory, and git worktree isolation. Local-first, agent-agnostic, FSL licensed.
 
 ## Commands & Extensions
 


### PR DESCRIPTION
Adds [Ivy Tendril](https://github.com/Ivy-Interactive/Ivy-Tendril) to **Agent Orchestration & CLI Tools**.

Ivy Tendril is a local-first desktop app that orchestrates Gemini CLI alongside Claude Code, Codex, Copilot, and OpenCode through a plan-based lifecycle with:

- Verification gates (build, test, lint, format, AI review)
- Self-improving memory that learns from each session
- Human-in-the-loop at two checkpoints
- Git worktree isolation per task

Similar to Parallel Code, Bernstein, and ToutKit already in this section — Tendril orchestrates Gemini CLI as one of several supported agents in a structured pipeline.

- Website: https://tendril.ivy.app
- License: FSL (converts to Apache 2.0 after 2 years)

Entry added to the bottom of the section per CONTRIBUTING.md guidelines.