### PR TITLE
add authsome under Development Tools &amp; Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Tools that enhance your development workflow when using Gemini CLI.
 - [agentwatch](https://github.com/mishanefedov/agentwatch) - Local-only TUI + web dashboard that tails Gemini CLI sessions alongside Claude Code, Codex, Cursor, Hermes, and OpenClaw on one unified timeline. Parses tokens, tools, and per-turn cost from each Gemini CLI session (gemini-2.5-pro / flash rates), plus context compaction visualizer, MAD z-score anomaly detection, MCP server mode, and OpenTelemetry exporter. No cloud, no telemetry. macOS + Linux. MIT.
 - [agenttrace](https://github.com/luoyuctl/agenttrace) - Local-first TUI for Gemini CLI and AI coding agent session observability. Parses local logs for cost, tokens, tool failures, latency, anomalies, health gates, and diffs across Gemini CLI, Claude Code, Codex CLI, Aider, Cursor exports, OpenCode, and more.
 - [andrej-karpathy-skills](https://github.com/swarmclawai/andrej-karpathy-skills) - Npm installer for Karpathy-inspired GEMINI.md guidelines, plus adapters for Codex, Claude Code, Cursor, OpenCode, OpenClaw, Windsurf, and Aider.
+- [authsome](https://github.com/agentrhq/authsome) - Local credential broker for AI agents. OAuth2 and API key vault stored locally, a loopback HTTPS proxy injects credentials into outbound provider requests so the Gemini CLI agent never sees raw secrets. 45 providers bundled (GitHub, Google, OpenAI, Linear, Slack, Notion, Resend, Stripe, ...). Python 3.13+, MIT.
 
 ## Browser Extensions
 


### PR DESCRIPTION
hey, opening this to add authsome under Development Tools & Utilities.

authsome is a local credential broker for AI agents. log in once via OAuth2 (browser PKCE or device code) or API key, encrypted local vault stores credentials, a loopback HTTPS proxy injects them into outbound provider requests so the Gemini CLI agent never sees raw secrets. 45 providers bundled (14 OAuth2, 31 API key) including github, google, openai, linear, slack, notion, resend, stripe.

works across any agent CLI that makes authenticated outbound calls. happy to move the entry or reword if you prefer.

repo: https://github.com/agentrhq/authsome
website: https://authsome.ai
license: MIT