### PR TITLE
Add TWZRD Agent Intel MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Model Context Protocol servers that enable Gemini CLI integration with other AI 
 - [Xquik MCP](https://github.com/Xquik-dev/x-twitter-scraper) - X/Twitter data MCP server with 76 REST API endpoints, 20 extraction tools, account monitoring, and giveaway draws. Works with any MCP client including Gemini CLI.
 - [TokRepo MCP Server](https://github.com/henu-wang/tokrepo-mcp-server) - Search and install AI skills, prompts, MCP configs, and workflows from TokRepo from Gemini CLI and other MCP clients.
 - [prompt-to-asset](https://github.com/MohamedAbdallah-14/prompt-to-asset) - MCP server that generates production-ready visual assets (app icons, favicons, OG images, logos, wordmarks) by routing requests across 30+ image generation models. Zero API key required for first run via Pollinations and Stable Horde free tiers. Works with any MCP client including Gemini CLI.
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - On-chain agent trust scoring for Solana agents. Tools: `score_agent(wallet)`, `preflight_check(wallet)` (free), and `get_trust_receipt(wallet)` (HTTP 402 paid). Add via `{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}`. Works with any MCP client including Gemini CLI.
 
 ## Neovim Plugins
 


### PR DESCRIPTION
## What this adds

[TWZRD Agent Intel](https://intel.twzrd.xyz) to the **MCP Servers** section.

**Why it belongs here:** TWZRD Agent Intel is a production MCP server (streamable-http) for on-chain agent trust scoring. It enables Gemini CLI and other MCP clients to score Solana agent wallets, run preflight checks, and fetch cryptographic trust receipts — useful for any agentic workflow that interacts with autonomous on-chain agents.

**Tools:**
- `score_agent(wallet)` — free reputation score for any Solana wallet
- `preflight_check(wallet)` — free deployment safety check
- `get_trust_receipt(wallet)` — HTTP 402 micro-payment for a signed trust receipt

**Install / config:**
```json
{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}
```

Works with any MCP client including Gemini CLI.