### PR TITLE
Add Lockpaw to Development Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Tools that enhance your development workflow when using Gemini CLI.
 - [andrej-karpathy-skills](https://github.com/swarmclawai/andrej-karpathy-skills) - Npm installer for Karpathy-inspired GEMINI.md guidelines, plus adapters for Codex, Claude Code, Cursor, OpenCode, OpenClaw, Windsurf, and Aider.
 - [authsome](https://github.com/agentrhq/authsome) - Local credential broker for AI agents. OAuth2 and API key vault stored locally, a loopback HTTPS proxy injects credentials into outbound provider requests so the Gemini CLI agent never sees raw secrets. 45 providers bundled (GitHub, Google, OpenAI, Linear, Slack, Notion, Resend, Stripe, ...). Python 3.13+, MIT.
 - [Wasla](https://github.com/The-Untitled-Org/wasla) - TypeScript CLI that syncs agents, MCP configs, skills, commands, and workflow assets across Gemini CLI, Claude Code, Codex, OpenCode/OpenClaw, and GitHub Copilot workflows.
+- [Lockpaw](https://github.com/sorkila/lockpaw) - macOS menu bar screen guard for unattended Gemini CLI runs. One hotkey covers the screen and blocks input while the agent keeps running (no sleep), and the locked screen glows plus fires a notification when Gemini CLI needs input or finishes, via a `lockpaw ping` hook. Touch ID unlock. Also works with Claude Code and Codex. Native Swift, free, open source.
 
 ## Browser Extensions
 


### PR DESCRIPTION
Adds [Lockpaw](https://github.com/sorkila/lockpaw) — a free, open-source macOS menu bar screen guard for unattended agent runs.

What it does for Gemini CLI users: one hotkey covers the screen and blocks input while Gemini CLI keeps running (the Mac doesn't sleep), and the locked screen glows + fires a notification the moment the agent needs input or finishes. The hook is a simple `lockpaw ping` command; Touch ID unlocks. It also works with Claude Code and Codex, but the screen-guard + glow combo is built for exactly the walk-away-while-the-agent-works case.

Native Swift, ~10 MB, no analytics, MIT-licensed. Added to the bottom of Development Tools & Utilities per the contributing guidelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)