### PR TITLE
feat: add NotFair — Claude Code skills for SEO, Google Ads & Meta Ads

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ Cool projects that don't pertain to Gemini CLI specifically but do utilitize Gem
 
 - [Git-Alchemist](https://github.com/abduznik/Git-Alchemist) - A unified AI-powered CLI tool for automating GitHub repository management (issues, PRs, topics, profiles) powered by Gemini 3 and Gemma 3.
 - [toprank](https://github.com/nowork-studio/toprank) - Claude Code plugin for SEO and Google Ads that includes a Gemini cross-model review skill. Uses Gemini for second-opinion reviews on Google Ads campaigns, SEO metadata, and schema markup — leveraging Gemini's native Google ecosystem knowledge for higher-quality decisions than Claude alone. MIT, 107 stars.
+- [NotFair](https://github.com/nowork-studio/NotFair) - Open-source Claude Code skills for SEO, GEO, Google Ads, and Meta Ads. Connects to live data via Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP. Includes a `/notfair:gemini` cross-model review skill that runs Gemini as a second-opinion gate on ad campaigns, SEO metadata, and schema markup. MIT, ~2.9k stars.
 
 ## Contributing
 


### PR DESCRIPTION
Thanks for maintaining this list! I'd like to add **NotFair** ([nowork-studio/NotFair](https://github.com/nowork-studio/NotFair)), an open-source set of Claude Code agent skills for marketing work — SEO, GEO, Google Ads, and Meta Ads.

I placed it in the **Non-Gemini CLI** section alongside toprank (also from nowork-studio), since it connects to live data through the Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP, and ships a `/notfair:gemini` skill that calls Gemini as a second-opinion review gate on ad decisions and SEO metadata — the same Gemini-cross-model pattern that got toprank listed.

It's MIT licensed and has around ~2.9k stars.

Happy to adjust the description, move it to a different section, or trim anything that doesn't fit the list's style.