### PR TITLE
feat: add EGC - persistent memory MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,6 @@ Tools that enhance your development workflow when using Gemini CLI.
 - [Tintpad](https://github.com/sorkila/tintpad) - macOS menu bar launcher for the agentic-coding loop. One hotkey opens your terminal at the right repo with Gemini CLI (or Claude Code, Codex) already running. Frecency repo search, Safe/Default/YOLO run modes, git worktrees, headless background dispatch. Native Swift, local-only, free, open source.
 - [DOS](https://github.com/anthony-chaudhary/dos-kernel) - Deterministic trust kernel for coding agents: hooks that verify "done" claims against git evidence and refuse file collisions between concurrent agents. Wires into Gemini CLI with `dos init --hooks gemini`; also ships an MCP server. Python, MIT.
 - [skillet](https://github.com/Brattlof/skillet) - Zero-dependency Go CLI / package manager that installs Agent Skills and MCP servers into Gemini CLI (and other tools), plus Claude Code slash commands and hooks.
-
 - [EGC](https://github.com/Fmarzochi/EGC) - Persistent cross-session memory for Gemini CLI and 12 other AI coding tools. SQLite-backed state survives context resets, install with `npm install -g @egchq/egc`.
 
 ## Browser Extensions

--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ Tools that enhance your development workflow when using Gemini CLI.
 - [DOS](https://github.com/anthony-chaudhary/dos-kernel) - Deterministic trust kernel for coding agents: hooks that verify "done" claims against git evidence and refuse file collisions between concurrent agents. Wires into Gemini CLI with `dos init --hooks gemini`; also ships an MCP server. Python, MIT.
 - [skillet](https://github.com/Brattlof/skillet) - Zero-dependency Go CLI / package manager that installs Agent Skills and MCP servers into Gemini CLI (and other tools), plus Claude Code slash commands and hooks.
 
+- [EGC](https://github.com/Fmarzochi/EGC) - Persistent cross-session memory for Gemini CLI and 12 other AI coding tools. SQLite-backed state survives context resets, install with `npm install -g @egchq/egc`.
+
 ## Browser Extensions
 
 - [SRT Subtitle Translator Validator](https://github.com/VjayC/SRT-Subtitle-Translator-Validator) - Browser-based tool to translate SRT subtitles using your Gemini subscription via CLI Proxy API with automatic validation/error correction - no API keys needed.


### PR DESCRIPTION
## Summary

- Adds [EGC](https://github.com/Fmarzochi/EGC) to the Development Tools & Utilities section
- EGC is a persistent cross-session memory MCP server that keeps Gemini CLI context alive across sessions
- SQLite-backed, works with 13+ AI coding tools including Gemini CLI
- Install: `npm install -g @egchq/egc`

## Details

EGC integrates natively with Gemini CLI via MCP. It stores project state, decisions, and context in a local SQLite database so agents never start from zero after a context reset.