### PR TITLE
Add Lusha (B2B data enrichment) to MCP Servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ Services that expose Gemini CLI functionality through standard API protocols.
 
 Model Context Protocol servers that enable Gemini CLI integration with other AI tools.
 
+- [Lusha](https://github.com/lusha-oss/lusha-mcp-plugin) - B2B prospecting and data enrichment: find and enrich contacts and companies with verified emails, direct dials, mobile numbers, and real-time buying signals. Remote MCP server bundled with 4 prospecting skills and OAuth sign-in. Works with Gemini CLI (`gemini extensions install`) and Antigravity (`agy plugin install`).
 - [BGPT MCP](https://github.com/connerlambden/bgpt-mcp) - Search scientific papers and get structured experimental data (methods, results, sample sizes, quality scores) from full-text studies. Works with any MCP client including Gemini CLI.
 - [Helium MCP](https://github.com/connerlambden/helium-mcp) - Real-time news with bias scoring across 5,000+ sources, live stock/ETF/crypto data with AI bull/bear cases, ML options pricing, and balanced news synthesis. 9 tools, free tier. Works with any MCP client including Gemini CLI.
 - [ToolsForMCPServer](https://github.com/tanaikech/ToolsForMCPServer) - Bridges Gemini CLI with Google Workspace through Apps Script integration, automating document processing, spreadsheet manipulation, and workflow automation.


### PR DESCRIPTION
Adds [Lusha](https://github.com/lusha-oss/lusha-mcp-plugin) under **MCP Servers**.

Lusha is a remote MCP server for B2B prospecting and data enrichment — find and enrich contacts and companies with verified emails, direct dials, mobile numbers, and real-time buying signals. It bundles 4 prospecting skills and uses OAuth sign-in.

- Gemini CLI: `gemini extensions install https://github.com/lusha-oss/lusha-mcp-plugin`
- Antigravity CLI: `agy plugin install https://github.com/lusha-oss/lusha-mcp-plugin`