### PR TITLE
Add xberg-io plugins suite to Commands & Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Custom commands and extensions that add new capabilities to Gemini CLI.
 - [dRPC Agent Skills](https://github.com/drpcorg/drpc-agent-skills) - Query blockchain RPCs from Gemini CLI. Fetch balances, read contracts, and check gas prices via dRPC.
 - [OpenAccountants](https://github.com/openaccountants/openaccountants) - 371 tax classification skills across 134 countries. Classify bank statement transactions into VAT/GST, income tax, and social contribution categories with conservative defaults.
 - [gemini-discord](https://github.com/Yamato-main/gemini-discord) - Turn your local Gemini CLI agent into an always-on Discord presence that also doubles as your personal server admin.
+- [xberg-io plugins](https://github.com/xberg-io/plugins) - A suite of Gemini CLI extensions from Kreuzberg, Inc.: document extraction (xberg — 97+ formats with OCR), web crawling (crawlberg), HTML→Markdown, a universal LLM client for 143 providers (liter-llm), and code intelligence for 300+ languages (tree-sitter-language-pack). Install via `gemini extensions install`.
 
 ## Fun
 


### PR DESCRIPTION
Adds the **xberg-io plugins** suite (github.com/xberg-io/plugins, MIT) to Commands & Extensions — Gemini CLI extensions for document extraction (xberg, 97+ formats + OCR), web crawling (crawlberg), HTML→Markdown, a universal LLM client (liter-llm), and code intelligence (tree-sitter-language-pack). Each ships a `gemini-extension.json` and installs via `gemini extensions install`.
