### PR TITLE
Add CodeAgentSwarm to Agent Orchestration & CLI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Modified versions of Gemini CLI with enhanced features or alternative model supp
 - [ToutKit](https://github.com/toutkit/toutkit) - Desktop notebook with a built-in terminal that runs Gemini CLI alongside Claude Code and Codex; an in-app webview renders whatever the agent writes inline, and each note is a self-contained folder with its own SQLite, files, and scripts. Local-first, Electron, AGPL-3.0.
 - [Ivy Tendril](https://github.com/Ivy-Interactive/Ivy-Tendril) - Open-source desktop app that orchestrates Gemini CLI alongside Claude Code, Codex, and Copilot through a plan-based lifecycle with verification gates, self-improving memory, and git worktree isolation. Local-first, agent-agnostic, FSL licensed.
 - [postmortemthis](https://github.com/Softeria/postmortemthis) - Runs Gemini CLI alongside your other coding agents (Claude Code, Codex, Qwen, Vibe) in parallel and read-only over your diff, then synthesizes their reviews into one ship / no-ship verdict. A cross-model review panel.
+- [CodeAgentSwarm](https://www.codeagentswarm.com) - Desktop app (macOS, Windows) that runs multiple Gemini CLI terminals in parallel alongside Claude Code and Codex CLI, under human supervision. Desktop notifications when an agent finishes or needs input, cross-session conversation history, per-terminal file diffs, and an MCP kanban board.
 
 ## Commands & Extensions
 


### PR DESCRIPTION
Adds CodeAgentSwarm to Agent Orchestration & CLI Tools.

CodeAgentSwarm is a desktop app (macOS, Windows) that runs multiple Gemini CLI terminals in parallel, alongside Claude Code and Codex CLI, under human supervision: desktop notifications when an agent finishes or needs input, searchable cross-session conversation history, per-terminal file diffs, and a kanban task board the agents update over MCP. Added to the bottom of the section per the contribution guidelines.
