### PR TITLE
Add AgentBox to Agent Orchestration & CLI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Modified versions of Gemini CLI with enhanced features or alternative model supp
 - [Ivy Tendril](https://github.com/Ivy-Interactive/Ivy-Tendril) - Open-source desktop app that orchestrates Gemini CLI alongside Claude Code, Codex, and Copilot through a plan-based lifecycle with verification gates, self-improving memory, and git worktree isolation. Local-first, agent-agnostic, FSL licensed.
 - [postmortemthis](https://github.com/Softeria/postmortemthis) - Runs Gemini CLI alongside your other coding agents (Claude Code, Codex, Qwen, Vibe) in parallel and read-only over your diff, then synthesizes their reviews into one ship / no-ship verdict. A cross-model review panel.
 - [CodeAgentSwarm](https://www.codeagentswarm.com) - Desktop app (macOS, Windows) that runs multiple Gemini CLI terminals in parallel alongside Claude Code and Codex CLI, under human supervision. Desktop notifications when an agent finishes or needs input, cross-session conversation history, per-terminal file diffs, and an MCP kanban board.
+- [AgentBox](https://github.com/madarco/agentbox) - Run multiple coding agents (Gemini CLI, Claude Code, Codex, OpenCode) in parallel, each teleported into its own sandboxed VM — local Docker, self-hosted, or cloud (Hetzner, Daytona, Vercel, E2B, DigitalOcean). Sub-1s checkpoint startup; git credentials stay on the host. MIT.
 
 ## Commands & Extensions
 


### PR DESCRIPTION
Adds [AgentBox](https://github.com/madarco/agentbox) to the bottom of **Agent Orchestration & CLI Tools** (per CONTRIBUTING).

AgentBox runs Gemini CLI — alongside Claude Code, Codex, and OpenCode — in parallel, each teleported into its own sandboxed VM (local Docker, self-hosted, or cloud: Hetzner / Daytona / Vercel / E2B / DigitalOcean). Sub-1s checkpoint startup; git credentials stay on the host. MIT.