### PR TITLE
Add Antigravity CLI Tips to Documentation & Examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ Educational materials and documentation to try out Gemini CLI if you're new.
 - [gemini-cli-media-generation](https://github.com/vladkol/gemini-cli-media-generation) - An example of using Gemini CLI with MCP Servers for Genmedia and Gemini 2.5 Flash Image model (Nano-banana)
 - [gemini-cli-demos](https://github.com/palladius/gemini-cli-demos) - Ready-to-run demonstration scenarios showcasing Gemini CLI's capabilities, perfect for learning, presenting, or evaluating the tool.
 - [cli-demo-cookbook](https://github.com/ptone/cli-demo-cookbook) - Collection of demo scenario and casts for Gemini CLI.
+- [Antigravity CLI Tips](https://github.com/ykdojo/antigravity-cli-tips) - Practical tips for Antigravity CLI (`agy`), the official successor to Gemini CLI.
 
 ## Non-Gemini CLI
 


### PR DESCRIPTION
Adds [Antigravity CLI Tips](https://github.com/ykdojo/antigravity-cli-tips), a collection of practical tips for Antigravity CLI (`agy`), to the Documentation & Examples section.

Since Gemini CLI stopped serving consumer requests on June 18 and Antigravity CLI is its official successor ([announcement](https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/)), this seemed useful for readers migrating over. Entry added at the bottom of the section per the contributing guidelines.