### PR TITLE
Add 16-eyes to Commands & Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Custom commands and extensions that add new capabilities to Gemini CLI.
 - [OpenAccountants](https://github.com/openaccountants/openaccountants) - 371 tax classification skills across 134 countries. Classify bank statement transactions into VAT/GST, income tax, and social contribution categories with conservative defaults.
 - [gemini-discord](https://github.com/Yamato-main/gemini-discord) - Turn your local Gemini CLI agent into an always-on Discord presence that also doubles as your personal server admin.
 - [xberg-io plugins](https://github.com/xberg-io/plugins) - A suite of Gemini CLI extensions from Kreuzberg, Inc.: document extraction (xberg — 97+ formats with OCR), web crawling (crawlberg), HTML→Markdown, a universal LLM client for 143 providers (liter-llm), and code intelligence for 300+ languages (tree-sitter-language-pack). Install via `gemini extensions install`.
+- [16-eyes](https://github.com/kigiela/16-eyes) - AI-driven security audits via custom Gemini CLI commands and subagents (also supports Claude Code, Cursor, GitHub Copilot) — profiles the repo, verifies every finding, adversarially disproves high-impact ones before they reach the report. Install via `npx 16-eyes install --target gemini`.
 
 ## Fun
 


### PR DESCRIPTION
Adds [16-eyes](https://github.com/kigiela/16-eyes) — a security-audit tool with a Gemini CLI adapter (custom TOML commands + subagents), also supporting Claude Code, Cursor, and GitHub Copilot. MIT licensed, npm-installable (`npx 16-eyes install --target gemini`).