### PR TITLE
Add Find MCP to MCP Servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ Model Context Protocol servers that enable Gemini CLI integration with other AI 
 - [Godot-MCP](https://github.com/IvanMurzak/Godot-MCP) - Open-source MCP server connecting AI agents to the Godot Editor and runtime (Godot 4.x, C#).
 - [Unreal-MCP](https://github.com/IvanMurzak/Unreal-MCP) - Open-source MCP server connecting AI agents to Unreal Engine 5.7, editor and runtime (C++ plugin + .NET sidecar).
 - [GameDev-MCP-Server](https://github.com/IvanMurzak/GameDev-MCP-Server) - Open-source, engine-agnostic MCP server shared by Unity-MCP, Godot-MCP, and Unreal-MCP.
+- [Find MCP](https://github.com/agentage/find-mcp) - Search 17,000+ MCP servers synced from the official MCP registry (registry.modelcontextprotocol.io). Remote Streamable HTTP (`https://catalog.agentage.io/mcp`, no auth for search) or stdio (`npx -y @agentage/find-mcp`). Works with Gemini CLI: `gemini mcp add --transport http find-mcp https://catalog.agentage.io/mcp`.
 
 ## Neovim Plugins
 


### PR DESCRIPTION
Adds Find MCP to the MCP Servers section of README.md (bottom of section, per CONTRIBUTING.md).

- GitHub: https://github.com/agentage/find-mcp
- npm: @agentage/find-mcp (stdio: npx -y @agentage/find-mcp)
- Remote: Streamable HTTP https://catalog.agentage.io/mcp (no auth needed for search)
- Web UI: https://catalog.agentage.io/mcp
- Official registry entry: io.agentage/find-mcp

Find MCP is an MCP server for discovering other MCP servers - it searches the agentage MCP Catalog (17,000+ servers synced from the official MCP registry, registry.modelcontextprotocol.io). Works with Gemini CLI via: gemini mcp add --transport http find-mcp https://catalog.agentage.io/mcp

Disclosure: I maintain Find MCP.
