### PR TITLE
Add wiki to Commands & Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Custom commands and extensions that add new capabilities to Gemini CLI.
 - [gemini-discord](https://github.com/Yamato-main/gemini-discord) - Turn your local Gemini CLI agent into an always-on Discord presence that also doubles as your personal server admin.
 - [xberg-io plugins](https://github.com/xberg-io/plugins) - A suite of Gemini CLI extensions from Kreuzberg, Inc.: document extraction (xberg — 97+ formats with OCR), web crawling (crawlberg), HTML→Markdown, a universal LLM client for 143 providers (liter-llm), and code intelligence for 300+ languages (tree-sitter-language-pack). Install via `gemini extensions install`.
 - [16-eyes](https://github.com/kigiela/16-eyes) - AI-driven security audits via custom Gemini CLI commands and subagents (also supports Claude Code, Cursor, GitHub Copilot) — profiles the repo, verifies every finding, adversarially disproves high-impact ones before they reach the report. Install via `npx 16-eyes install --target gemini`.
+- [wiki](https://github.com/plasma-ai/wiki) - Indexed Markdown knowledge bases with a CLI and installable Agent Skill. `wiki install` writes the skill to `~/.agents/skills`, which Gemini CLI discovers.
 
 ## Fun
 


### PR DESCRIPTION
## Summary

- Add wiki to Commands & Extensions.
- Note its indexed Markdown workflow and Gemini CLI Agent Skill discovery path.
- Match the existing one-line entry format and append it to the section.

## Verification

- `wiki install` copies the Agent Skill to `~/.agents/skills`.
- Gemini CLI's official Agent Skills documentation lists `~/.agents/skills/` as a user discovery alias.
- The repository and PyPI package resolve.
- `git diff --check` passes.

Disclosure: I am affiliated with plasma-ai/wiki.