### PR TITLE
Add emem — verifiable Earth memory MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ Services that expose Gemini CLI functionality through standard API protocols.
 
 Model Context Protocol servers that enable Gemini CLI integration with other AI tools.
 
+- [emem](https://github.com/Vortx-AI/emem) - Shared, verifiable Earth memory for AI agents. Ed25519-signed, BLAKE3 content-addressed facts about any place on Earth — air quality, vegetation, flood, fire, elevation, deforestation. 104 tools, no API key, no signup. Remote Streamable HTTP. Install: `gemini extensions install https://emem.dev/gemini-extension.json`.
 - [Lusha](https://github.com/lusha-oss/lusha-mcp-plugin) - B2B prospecting and data enrichment: find and enrich contacts and companies with verified emails, direct dials, mobile numbers, and real-time buying signals. Remote MCP server bundled with 4 prospecting skills and OAuth sign-in. Works with Gemini CLI (`gemini extensions install`) and Antigravity (`agy plugin install`).
 - [BGPT MCP](https://github.com/connerlambden/bgpt-mcp) - Search scientific papers and get structured experimental data (methods, results, sample sizes, quality scores) from full-text studies. Works with any MCP client including Gemini CLI.
 - [Helium MCP](https://github.com/connerlambden/helium-mcp) - Real-time news with bias scoring across 5,000+ sources, live stock/ETF/crypto data with AI bull/bear cases, ML options pricing, and balanced news synthesis. 9 tools, free tier. Works with any MCP client including Gemini CLI.


### PR DESCRIPTION
## What is emem

[emem](https://github.com/Vortx-AI/emem) is shared, verifiable Earth memory for AI agents — Ed25519-signed, BLAKE3 content-addressed facts about any place on Earth.

**Install:**
\`\`\`
gemini extensions install https://emem.dev/gemini-extension.json
\`\`\`

**What it gives Gemini CLI users:**
- Recall signed facts about air quality, vegetation, flood extent, fire/burn severity, elevation, and deforestation for any place
- Every response includes an offline-verifiable Ed25519 receipt — no trust required
- Facts survive context compaction and session ends as cite-able `emem:fact:` tokens
- 104 MCP tools, no API key, no signup, no rate limits for reads
- Remote Streamable HTTP — works with any MCP client

**Example prompts after install:**
- *"Is the air safe in Delhi right now?"*
- *"Has there been recent deforestation near the Amazon?"*
- *"What is the flood risk at 28.6° N, 77.2° E?"*
- *"Create a memory token for the NDVI at Central Park so I can cite it later."*

**Links:** [Homepage](https://emem.dev) · [GitHub](https://github.com/Vortx-AI/emem) · [Extension manifest](https://emem.dev/gemini-extension.json) · Apache 2.0