### PR TITLE
Add GoodMemory MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ Model Context Protocol servers that enable Gemini CLI integration with other AI 
 - [Unreal-MCP](https://github.com/IvanMurzak/Unreal-MCP) - Open-source MCP server connecting AI agents to Unreal Engine 5.7, editor and runtime (C++ plugin + .NET sidecar).
 - [GameDev-MCP-Server](https://github.com/IvanMurzak/GameDev-MCP-Server) - Open-source, engine-agnostic MCP server shared by Unity-MCP, Godot-MCP, and Unreal-MCP.
 - [Find MCP](https://github.com/agentage/find-mcp) - Search 17,000+ MCP servers synced from the official MCP registry (registry.modelcontextprotocol.io). Remote Streamable HTTP (`https://catalog.agentage.io/mcp`, no auth for search) or stdio (`npx -y @agentage/find-mcp`). Works with Gemini CLI: `gemini mcp add --transport http find-mcp https://catalog.agentage.io/mcp`.
+- [GoodMemory](https://github.com/hjqcan/GoodMemory) - Local-first durable memory for Gemini CLI through standalone MCP, with scoped recall, provenance and trace inspection, and explicit forgetting. Read-only by default with opt-in governed writes; install with `npm install -g goodmemory@0.7.0` and follow the [Gemini CLI setup guide](https://github.com/hjqcan/GoodMemory/blob/main/docs/GoodMemory-Gemini-CLI-Setup-Guide.md).
 
 ## Neovim Plugins
 


### PR DESCRIPTION
## Summary

- add GoodMemory to the MCP Servers section
- link the dedicated Gemini CLI setup guide
- state the default read-only and opt-in write boundary

GoodMemory runs as a standalone MCP server for Gemini CLI and provides local-first, scoped durable memory with provenance/trace inspection and explicit forgetting.

## Validation

- `git diff --check`
- confirmed the documented npm release is `goodmemory@0.7.0`
- confirmed the repository includes a Gemini CLI-specific setup guide