### PR TITLE
Add MCP Config Doctor to Development Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ Tools that enhance your development workflow when using Gemini CLI.
 - [DOS](https://github.com/anthony-chaudhary/dos-kernel) - Deterministic trust kernel for coding agents: hooks that verify "done" claims against git evidence and refuse file collisions between concurrent agents. Wires into Gemini CLI with `dos init --hooks gemini`; also ships an MCP server. Python, MIT.
 - [skillet](https://github.com/Brattlof/skillet) - Zero-dependency Go CLI / package manager that installs Agent Skills and MCP servers into Gemini CLI (and other tools), plus Claude Code slash commands and hooks.
 - [EGC](https://github.com/Fmarzochi/EGC) - Persistent cross-session memory for Gemini CLI and 12 other AI coding tools. SQLite-backed state survives context resets, install with `npm install -g @egchq/egc`.
+- [MCP Config Doctor](https://mcpconfigdoctor.online/) - Browser-local diagnostic that validates Gemini CLI `~/.gemini/settings.json` MCP server entries (shape, env/secret references, transport fields). Also covers Claude Code, Codex CLI, and VS Code MCP configs. No account, no telemetry, no remote calls — runs entirely in the browser.
 
 ## Browser Extensions
 


### PR DESCRIPTION
## Summary

Adds **MCP Config Doctor** (https://mcpconfigdoctor.online/) to the **Development Tools & Utilities** section.

## Disclosure

- **Operator relationship**: This site is operated by the same author submitting this PR (`suyaoyong`). It is a free, browser-local diagnostic with no account or signup.
- **Analytics boundary**: The site uses no third-party analytics, no telemetry, and no remote calls. All validation runs client-side in the browser.
- **No payment / no link exchange**: This is an unsolicited contribution to a public awesome list; no commercial arrangement exists with the maintainer.

## Why it fits

MCP Config Doctor has a dedicated Gemini CLI preset (`/gemini-cli-mcp-config-doctor`) that diagnoses `~/.gemini/settings.json` `mcpServers` structure, env reference integrity, and transport fields. It complements existing entries like `agnix` (linter) and `vsync` (format converter) in the same surface area.
