### PR TITLE
Add ArmorGemini to Commands & Extensions section

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Custom commands and extensions that add new capabilities to Gemini CLI.
 - [xberg-io plugins](https://github.com/xberg-io/plugins) - A suite of Gemini CLI extensions from Kreuzberg, Inc.: document extraction (xberg — 97+ formats with OCR), web crawling (crawlberg), HTML→Markdown, a universal LLM client for 143 providers (liter-llm), and code intelligence for 300+ languages (tree-sitter-language-pack). Install via `gemini extensions install`.
 - [16-eyes](https://github.com/kigiela/16-eyes) - AI-driven security audits via custom Gemini CLI commands and subagents (also supports Claude Code, Cursor, GitHub Copilot) — profiles the repo, verifies every finding, adversarially disproves high-impact ones before they reach the report. Install via `npx 16-eyes install --target gemini`.
 - [wiki](https://github.com/plasma-ai/wiki) - Indexed Markdown knowledge bases with a CLI and installable Agent Skill. `wiki install` writes the skill to `~/.agents/skills`, which Gemini CLI discovers.
+- [ArmorGemini](https://github.com/armoriq/armorGemini) - Intent-based security enforcement for the Gemini CLI. Every tool call is checked against your ArmorIQ policy via `BeforeTool` / `AfterTool` hooks before it runs. Blocks intent drift, unauthorized tool use, and PII/PCI leaks. Install: `curl -fsSL https://armoriq.ai/install_armorgemini.sh | bash`.
 
 ## Fun
 


### PR DESCRIPTION
## What

Adds [ArmorGemini](https://github.com/armoriq/armorGemini) to the **Commands & Extensions** section (bottom of the section, matching the format of the entries above).

## Why here

ArmorGemini is a Gemini CLI extension that adds intent-based security enforcement: every tool call goes through `BeforeTool` / `AfterTool` hooks and is checked against an ArmorIQ policy before it runs. Nearest peer already in this section is [`16-eyes`](https://github.com/kigiela/16-eyes) (AI-driven security audits via custom Gemini CLI commands) — same shape, security-focused, wraps the CLI.

Also submitted to the child list [Piebald-AI/awesome-gemini-cli-extensions#26](https://github.com/Piebald-AI/awesome-gemini-cli-extensions/pull/26); dual-listing follows the pattern established by other entries in this list (gemini-discord, brooks-lint, Pickle Rick, Listen, etc. all appear in both lists).

## Entry

```
- [ArmorGemini](https://github.com/armoriq/armorGemini) - Intent-based security enforcement for the Gemini CLI. Every tool call is checked against your ArmorIQ policy via `BeforeTool` / `AfterTool` hooks before it runs. Blocks intent drift, unauthorized tool use, and PII/PCI leaks. Install: `curl -fsSL https://armoriq.ai/install_armorgemini.sh | bash`.
```

## Repo hygiene

- Public GitHub repository, MIT-licensed
- `gemini-cli-extension` topic set on the repo's About section
- `gemini-extension.json` manifest at repo root — auto-listed at [geminicli.com/extensions](https://geminicli.com/extensions/browse/)
- Ships `.gemini/settings.json` hooks + `.gemini/commands/armor/*.toml` custom slash commands (`/armor:list`, `/armor:add`, `/armor:template`, `/armor:help`)
- LICENSE, CONTRIBUTING, CODE_OF_CONDUCT, README, custom social preview all present

Per CONTRIBUTING.md, entry added at the bottom of the appropriate section.
