### PR TITLE
Add LWC project memory for Gemini CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ Model Context Protocol servers that enable Gemini CLI integration with other AI 
 - [RunAPI MCP](https://github.com/runapi-ai/mcp) - Remote MCP server for browsing model catalogs, checking pricing, and creating image, video, music, audio, and other model API tasks through RunAPI. Works with Gemini CLI: `gemini mcp add --transport http runapi https://mcp.runapi.ai/mcp`.
 - [AISO Tools MCP](https://aisotools.com/mcp) - Query a catalog of 1,636 AI tools from the CLI: keyword/category/pricing search, side-by-side comparison, and alternatives lookup, with a canonical citation URL on every result. Remote Streamable HTTP, no API key. Works with any MCP client including Gemini CLI: `gemini mcp add --transport http aisotools https://aisotools.com/api/mcp`.
 - [Lians](https://github.com/Lians-ai/Lians) - Open-source, local-first memory for Gemini CLI and other AI agents. Durable cross-session recall through a two-tool MCP extension, with no account or API key. Install: `gemini extensions install https://github.com/Lians-ai/Lians`.
+- [LWC](https://github.com/JanYork/llm-wiki-cli) - Local-first, source-grounded project memory for Gemini CLI and other coding agents. Provides bounded recall, citations, atomic changesets, an installable Agent Skill, and a read-only stdio MCP server (`lwc serve --mcp`). Apache-2.0.
 
 ## Neovim Plugins
 


### PR DESCRIPTION
## Summary

Adds LWC to MCP Servers as local-first, source-grounded project memory for Gemini CLI and other coding agents.

LWC provides bounded recall, citations, atomic changesets, an installable Agent Skill, and a read-only stdio MCP server.

## Validation

- Repository: https://github.com/JanYork/llm-wiki-cli
- Direct Skill: https://github.com/JanYork/llm-wiki-cli/tree/main/skills/using-lwc
- MCP command: `lwc serve --mcp`
- License: Apache-2.0
- `git diff --check` passes

Disclosure: self-nomination; I maintain LWC.
