### PR TITLE
Add SandBase CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Modified versions of Gemini CLI with enhanced features or alternative model supp
 - [Better Agent](https://github.com/ofekron/better-agent) - Local workspace for persistent Gemini CLI, Claude Code, and Codex sessions with detached execution, restart recovery, parallel forks, delegation, and approval gates. Source-available; free for non-commercial use.
 - [Agentlas OS](https://github.com/agentlas-ai/Agentlas-OS) - Local-first Agent Operation Environment (AOE) that installs into Gemini CLI and other supported hosts to build, route, and run specialist agent teams with portable packages, permissions, and verification gates.
 - [intentic](https://github.com/intentic/intentic) - Self-hosted workspace that runs Gemini CLI over ACP (`gemini --experimental-acp`) alongside Claude Code, Codex, and OpenCode. Each agent gets its own Docker container and git worktree on hardware you own; terminals survive disconnects, any browser or phone reopens the same fleet, and changes land through per-file, per-hunk diff review. Scheduled and webhook-triggered runs. MIT.
+- [SandBase CLI](https://github.com/sandbaseai/cli) - Open-source CLI and MCP bridge that configures Gemini CLI and other AI coding agents to access 2,000+ AI models through one account.
 
 ## Commands & Extensions
 


### PR DESCRIPTION
## Summary

- Add SandBase CLI to **Agent Orchestration & CLI Tools**.
- Describe its direct Gemini CLI support and MCP bridge.
- Use the current product scope: access to **2,000+ AI models** through one account.

## Validation

- Confirmed there was no existing SandBase entry.
- Followed the repository's required entry format and appended it to the appropriate section.
- `git diff --check` passes.

## Disclosure

I am affiliated with the SandBase project. This contribution and PR text were prepared with AI assistance and reviewed before submission.