### PR TITLE
Add Agent QA MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ Model Context Protocol servers that enable Gemini CLI integration with other AI 
 - [AISO Tools MCP](https://aisotools.com/mcp) - Query a catalog of 1,636 AI tools from the CLI: keyword/category/pricing search, side-by-side comparison, and alternatives lookup, with a canonical citation URL on every result. Remote Streamable HTTP, no API key. Works with any MCP client including Gemini CLI: `gemini mcp add --transport http aisotools https://aisotools.com/api/mcp`.
 - [Lians](https://github.com/Lians-ai/Lians) - Open-source, local-first memory for Gemini CLI and other AI agents. Durable cross-session recall through a two-tool MCP extension, with no account or API key. Install: `gemini extensions install https://github.com/Lians-ai/Lians`.
 - [LWC](https://github.com/JanYork/llm-wiki-cli) - Local-first, source-grounded project memory for Gemini CLI and other coding agents. Provides bounded recall, citations, atomic changesets, an installable Agent Skill, and a read-only stdio MCP server (`lwc serve --mcp`). Apache-2.0.
+- [Agent QA](https://github.com/vostride/agent-qa) - Open-source self-improving QA agent for natural-language web and mobile tests. Run its MCP server with `agent-qa mcp` to let Gemini CLI author, execute, inspect, triage, and repair tests.
 
 ## Neovim Plugins
 


### PR DESCRIPTION
## Summary

- add Agent QA to the MCP Servers section
- document the `agent-qa mcp` entrypoint
- explain the testing workflow exposed to Gemini CLI

Agent QA is an open-source self-improving QA agent for software teams. Its MCP server exposes tools for authoring, running, inspecting, triaging, and repairing natural-language web and mobile tests.

Disclosure: I am affiliated with Agent QA.
