### PR TITLE
Add deja-vu to MCP Servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ Model Context Protocol servers that enable Gemini CLI integration with other AI 
 - [Lians](https://github.com/Lians-ai/Lians) - Open-source, local-first memory for Gemini CLI and other AI agents. Durable cross-session recall through a two-tool MCP extension, with no account or API key. Install: `gemini extensions install https://github.com/Lians-ai/Lians`.
 - [LWC](https://github.com/JanYork/llm-wiki-cli) - Local-first, source-grounded project memory for Gemini CLI and other coding agents. Provides bounded recall, citations, atomic changesets, an installable Agent Skill, and a read-only stdio MCP server (`lwc serve --mcp`). Apache-2.0.
 - [Agent QA](https://github.com/vostride/agent-qa) - Open-source self-improving QA agent for natural-language web and mobile tests. Run its MCP server with `agent-qa mcp` to let Gemini CLI author, execute, inspect, triage, and repair tests.
+- [deja-vu](https://github.com/vshulcz/deja-vu) - Local memory over the session files Gemini CLI and 19 other agents already write to disk, so a new session can search what you did before — including the months before you installed it. MCP tools plus auto-recall on every prompt; one Go binary, no network calls, MIT. Install: `deja install gemini-auto`.
 
 ## Neovim Plugins
 


### PR DESCRIPTION
deja-vu indexes the session files Gemini CLI already writes under ~/.gemini, so a new session can search what you did before instead of re-deriving it — including the months before you installed it. It does the same for 19 other agents, which is what makes it useful when you move between them.

MCP server plus auto-recall on every prompt (`deja install gemini-auto`). One Go binary, no network calls, MIT.