### PR TITLE
Add Punchcard to Commands & Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Custom commands and extensions that add new capabilities to Gemini CLI.
 - [16-eyes](https://github.com/kigiela/16-eyes) - AI-driven security audits via custom Gemini CLI commands and subagents (also supports Claude Code, Cursor, GitHub Copilot) — profiles the repo, verifies every finding, adversarially disproves high-impact ones before they reach the report. Install via `npx 16-eyes install --target gemini`.
 - [wiki](https://github.com/plasma-ai/wiki) - Indexed Markdown knowledge bases with a CLI and installable Agent Skill. `wiki install` writes the skill to `~/.agents/skills`, which Gemini CLI discovers.
 - [ArmorGemini](https://github.com/armoriq/armorGemini) - Intent-based security enforcement for the Gemini CLI. Every tool call is checked against your ArmorIQ policy via `BeforeTool` / `AfterTool` hooks before it runs. Blocks intent drift, unauthorized tool use, and PII/PCI leaks. Install: `curl -fsSL https://armoriq.ai/install_armorgemini.sh | bash`.
+- [Punchcard](https://github.com/Maksim-Burtsev/punchcard) - Architecture-level code review grounded in thirty engineering books distilled into 78 principles. Three independent passes over a working tree, branch or PR, merged into one verdict; every blocker demonstrated by running the code. Install with `npx skills add Maksim-Burtsev/punchcard -a gemini-cli`.
 
 ## Fun
 


### PR DESCRIPTION
Adding my skill **[Punchcard](https://github.com/Maksim-Burtsev/punchcard)** to *Commands & Extensions*.

It reviews a working tree, a branch or a pull request at the architecture level — module boundaries, dependency direction, the data model, error paths, the cost of the next change — and deliberately says nothing about naming or formatting.

Two things make it different from the usual review prompt:

- **A constitution instead of vibes.** Thirty classic software books, read cover to cover and distilled into 349 principles, then into the 78 that decide a review. Every finding cites the principle it rests on, so the reasoning is arguable rather than the tone.
- **Blockers are demonstrated, not asserted.** Three independent search passes, then a single judge that verifies each candidate by actually running the code on both branches. What it can't reproduce, it doesn't report. Back comes the same shape every time: one verdict, a summary table, one card per finding.

**Gemini CLI support** is a real install path, not a README claim:

```
npx skills add Maksim-Burtsev/punchcard -a gemini-cli
```

That writes the skill into `~/.gemini/skills/`; invoke it as `/punchcard <target>`, and add the word `post` next to the target to have the review posted into a GitHub PR or GitLab MR. It is one self-contained directory, so `cp -r skills/punchcard` works too.

MIT, currently v1.4.0. Entry added to the bottom of the section, in the existing `- [Name](URL) - Description` format. Thanks for maintaining the list!
