### PR TITLE
Add godmode to Agent Orchestration & CLI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Modified versions of Gemini CLI with enhanced features or alternative model supp
 - [Agentlas OS](https://github.com/agentlas-ai/Agentlas-OS) - Local-first Agent Operation Environment (AOE) that installs into Gemini CLI and other supported hosts to build, route, and run specialist agent teams with portable packages, permissions, and verification gates.
 - [intentic](https://github.com/intentic/intentic) - Self-hosted workspace that runs Gemini CLI over ACP (`gemini --experimental-acp`) alongside Claude Code, Codex, and OpenCode. Each agent gets its own Docker container and git worktree on hardware you own; terminals survive disconnects, any browser or phone reopens the same fleet, and changes land through per-file, per-hunk diff review. Scheduled and webhook-triggered runs. MIT.
 - [SandBase CLI](https://github.com/sandbaseai/cli) - Open-source CLI and MCP bridge that configures Gemini CLI and other AI coding agents to access 2,000+ AI models and APIs through one account.
+- [godmode](https://github.com/arbazkhan971/godmode) - Discipline layer for AI coding agents: 135 skills and 7 subagents that wrap Gemini CLI (and Claude Code, Codex, Cursor, OpenCode, Amp, and pi) in a measure → modify → verify → keep/revert loop with automatic rollback of failed changes. MIT.
 
 ## Commands & Extensions
 


### PR DESCRIPTION
Adds `godmode` to the **Agent Orchestration & CLI Tools** section.

godmode is a discipline-layer skill plugin for AI coding agents that ships 135 skills and 7 subagents. Its core loop is measure → modify → verify → keep/revert, so every change is backed by evidence and failed experiments are reverted. It works with Gemini CLI via its Gemini adapter, and also wraps Claude Code, Codex, Cursor, OpenCode, Amp, and pi.

- Repo: https://github.com/arbazkhan971/godmode
- Release: https://github.com/arbazkhan971/godmode/releases/tag/v2.0.0
- License: MIT

I am the author. Entry follows the existing section format - happy to adjust placement or wording.
