### PR TITLE
Add Knowledge Delta Skills to Commands & Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Custom commands and extensions that add new capabilities to Gemini CLI.
 - [wiki](https://github.com/plasma-ai/wiki) - Indexed Markdown knowledge bases with a CLI and installable Agent Skill. `wiki install` writes the skill to `~/.agents/skills`, which Gemini CLI discovers.
 - [ArmorGemini](https://github.com/armoriq/armorGemini) - Intent-based security enforcement for the Gemini CLI. Every tool call is checked against your ArmorIQ policy via `BeforeTool` / `AfterTool` hooks before it runs. Blocks intent drift, unauthorized tool use, and PII/PCI leaks. Install: `curl -fsSL https://armoriq.ai/install_armorgemini.sh | bash`.
 - [Punchcard](https://github.com/Maksim-Burtsev/punchcard) - Architecture-level code review grounded in thirty engineering books distilled into 78 principles. Three independent passes over a working tree, branch or PR, merged into one verdict; every blocker demonstrated by running the code. Install with `npx skills add Maksim-Burtsev/punchcard -a gemini-cli`.
+- [Knowledge Delta Skills](https://github.com/sergeyizmailov/knowledge-delta-skills) - Portable `SKILL.md` skills for media buying, frontend, security, research, and skill authoring, each kept to what a frontier model does not already reliably know. Copy any skill directory into `~/.gemini/skills/` and Gemini CLI discovers it.
 
 ## Fun
 


### PR DESCRIPTION
One entry under **Commands & Extensions**, alongside the other installable Agent Skills already listed there.

[Knowledge Delta Skills](https://github.com/sergeyizmailov/knowledge-delta-skills) — portable `SKILL.md` skills covering media buying (Meta/Google ads, trackers, measurement validity), frontend, security, research, and skill authoring itself.

Gemini CLI relevance: the skills are written to the portable Agent Skills format and the README documents Gemini CLI's own skills directory (`~/.gemini/skills/`, alias `~/.agents/skills/`) alongside the other runtimes, verified against your docs. Copying a skill directory there is the whole install.

What makes the collection different from a general skill pack: each skill starts from a clean-session baseline of the real tasks, and whatever the model already handles correctly is cut instead of documented. Method write-up: [docs/METHODOLOGY.md](https://github.com/sergeyizmailov/knowledge-delta-skills/blob/master/docs/METHODOLOGY.md).

MIT, CI validates each skill's frontmatter against a JSON schema on every push.