### PR TITLE
Add claude-skills-pro — 15 engineering-workflow skills (7 free/MIT)

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,8 @@ Tools that enhance your development workflow when using Gemini CLI.
 - [MCP Config Doctor](https://mcpconfigdoctor.online/) - Browser-local diagnostic that validates Gemini CLI `~/.gemini/settings.json` MCP server entries (shape, env/secret references, transport fields). Also covers Claude Code, Codex CLI, and VS Code MCP configs. No account, no telemetry, no remote calls — runs entirely in the browser.
 - [Agent Island](https://github.com/tristan666666/agent-island) - Free, MIT-licensed native status companion for Gemini CLI, Claude Code, Codex, Grok, and Cursor sessions. Shows local working, stalled, and your-turn state, and tracks Gemini Pro and Flash quota separately, without an Agent Island account or product telemetry. macOS and Windows.
 - [Hexis](https://github.com/Bevel-Software/Hexis) - Git-backed platform for skills, tools, and context for AI agents, available to Gemini CLI through a remote OAuth MCP server.
+- [claude-skills-pro](https://github.com/Hahaknight/claude-skills-pro) - 15 engineering-workflow skills (7-dimension code review, root-cause debugging, bug-catching test generation, behavior-preserving refactor, zero-downtime DB migration; 7 free/MIT) with CN/EN handbooks. Installs into Gemini CLI via the open skills installer: `npx skills add Hahaknight/claude-skills-pro --agent gemini-cli` (install path verified end-to-end in Gemini CLI).
+
 
 ## Browser Extensions
 


### PR DESCRIPTION
Adds [claude-skills-pro](https://github.com/Hahaknight/claude-skills-pro) to **Development Tools & Utilities**.

15 engineering-workflow skills — 7-dimension code review, root-cause debugging (reproduce → bisect → single hypothesis), bug-catching test generation, behavior-preserving refactor, zero-downtime DB migration. 7 free/MIT, CN/EN handbooks included.

Installs into Gemini CLI via the open skills installer (verified end-to-end):

```
npx skills add Hahaknight/claude-skills-pro --agent gemini-cli
```

Real output samples: [EXAMPLES.md](https://github.com/Hahaknight/claude-skills-pro/blob/main/EXAMPLES.md)