### PR TITLE
Fix README table of contents: add 7 missing sections, repair 3 broken anchors

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,20 +61,24 @@ A curated list of awesome tools, extensions, and resources for [Gemini CLI](http
 ## Contents
 
 - [Contents](#contents)
+- [New](#tada-new)
 - [Official](#official)
 - [Interfaces](#interfaces)
 - [Forks](#forks)
+- [Agent Orchestration \& CLI Tools](#agent-orchestration--cli-tools)
 - [Fun](#fun)
 - [Development Tools \& Utilities](#development-tools--utilities)
+- [Browser Extensions](#browser-extensions)
 - [SDKs](#sdks)
 - [API Bridges \& Proxies](#api-bridges--proxies)
 - [Commands \& Extensions](#commands--extensions)
 - [Prompts](#prompts)
+- [Education \& Study Tools](#education--study-tools)
 - [MCP Servers](#mcp-servers)
 - [Neovim Plugins](#neovim-plugins)
-- [Development Frameworks \& Orchestration](#development-frameworks--orchestration)
-- [Documentation \& Learning Resources](#documentation--learning-resources)
-- [Demo Collections \& Examples](#demo-collections--examples)
+- [Frameworks](#frameworks)
+- [Documentation \& Examples](#documentation--examples)
+- [Non-Gemini CLI](#non-gemini-cli)
 - [Contributing](#contributing)
 
 ## Official


### PR DESCRIPTION
### What
The README's Contents section was out of sync with the document:

- **7 H2 sections missing from the TOC**: `New`, `Agent Orchestration & CLI Tools`, `Browser Extensions`, `Education & Study Tools` (plus 3 that were listed under wrong titles)
- **3 dead anchors** pointing at sections that don't exist: `#development-frameworks--orchestration`, `#documentation--learning-resources`, `#demo-collections--examples`

### Fix
- Added the 4 missing entries and corrected the 3 stale ones to the actual section anchors (`#frameworks`, `#documentation--examples`, `#non-gemini-cli`)
- Kept the existing list format untouched

### Verification
```
H2_COUNT=20  TOC_COUNT=20  MISSING=0  STALE=0
```
Pure documentation change — no code touched. Happy to adjust placement if maintainers prefer a different grouping.