### PR TITLE
Add Devie AI Quota Tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ Tools that enhance your development workflow when using Gemini CLI.
 - [Agent Island](https://github.com/tristan666666/agent-island) - Free, MIT-licensed native status companion for Gemini CLI, Claude Code, Codex, Grok, and Cursor sessions. Shows local working, stalled, and your-turn state, and tracks Gemini Pro and Flash quota separately, without an Agent Island account or product telemetry. macOS and Windows.
 - [Hexis](https://github.com/Bevel-Software/Hexis) - Git-backed platform for skills, tools, and context for AI agents, available to Gemini CLI through a remote OAuth MCP server.
 - [claude-skills-pro](https://github.com/Hahaknight/claude-skills-pro) - 15 engineering-workflow skills (7-dimension code review, root-cause debugging, bug-catching test generation, behavior-preserving refactor, zero-downtime DB migration; 7 free/MIT) with CN/EN handbooks. Installs into Gemini CLI via the open skills installer: `npx skills add Hahaknight/claude-skills-pro --agent gemini-cli` (install path verified end-to-end in Gemini CLI).
+- [Devie AI Quota Tracker](https://github.com/mathdevie/devie-ai-quota-tracker) - Dashboard and macOS menu bar for tracking AI subscription quotas in one place (Claude Code, Codex, Gemini CLI, GitHub Copilot, and Cursor). Supports multi-accounts, notifications, and session-timer start optimization.
 
 
 ## Browser Extensions


### PR DESCRIPTION
Adds [Devie AI Quota Tracker](https://github.com/mathdevie/devie-ai-quota-tracker) to the Development Tools & Utilities section.

It is an open-source (MIT) macOS menu bar app and dashboard that tracks AI subscription quotas for Gemini CLI, Claude Code, Codex, GitHub Copilot, and Cursor, with multi-account support, notifications, and session-timer start optimization.