### PR TITLE
Update renamed repo link and http links to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,9 +138,9 @@ Custom commands and extensions that add new capabilities to Gemini CLI.
 - [ATXP](https://github.com/atxp-dev/atxp) - Give your Gemini CLI agent a wallet, email address, phone number, and 100+ paid MCP tools (web search, image gen, SMS, voice, LLM gateway). Self-register with `gemini extensions install https://github.com/atxp-dev/atxp` — no human login required, $5 free credits included.
 - [brooks-lint](https://github.com/hyhmrright/brooks-lint) - AI code reviews grounded in six classic engineering books. Diagnoses decay risks with structured findings (Symptom → Source → Consequence → Remedy).
 - [gemini-notifier](https://github.com/thoreinstein/gemini-notifier) - A Gemini extension to send native system-level notifications when Gemini requests permissions.
-- [Pickle Rick](http://github.com/galz10/pickle-rick-extension) - This extension transforms the Gemini CLI into "Pickle Rick," a hyper-intelligent, arrogant, yet extremely competent engineering persona. It enforces a rigid, iterative software development lifecycle through continuous AI agent loops.
+- [Pickle Rick](https://github.com/galdawave/pickle-rick-extension) - This extension transforms the Gemini CLI into "Pickle Rick," a hyper-intelligent, arrogant, yet extremely competent engineering persona. It enforces a rigid, iterative software development lifecycle through continuous AI agent loops.
 - [gemini-beads](https://github.com/thoreinstein/gemini-beads) - Git-backed persistent memory and task management for Gemini CLI.
-- [Conductor](http://github.com/gemini-cli-extensions/conductor) - Conductor is a Gemini CLI extension that allows you to specify, plan, and implement software features.
+- [Conductor](https://github.com/gemini-cli-extensions/conductor) - Conductor is a Gemini CLI extension that allows you to specify, plan, and implement software features.
 - [Listen](https://github.com/automateyournetwork/GeminiCLI_Listen_Extension) - Run Gemini CLI as a server with /listen commands.
 - [Screenshare](https://github.com/automateyournetwork/GeminiCLI_ScreenShare_Extension) - Screen sharing via MCP and custom slash commands.
 - [pyATS](https://github.com/automateyournetwork/pyATS_GeminiCLI_Extension) - pyATS integration for network testing.


### PR DESCRIPTION
### What
Two leftover `http://` links in the Commands & Extensions section, one of which points at a renamed repository:

| Entry | Before | After |
|---|---|---|
| Pickle Rick | `http://github.com/galz10/pickle-rick-extension` | `https://github.com/galdawave/pickle-rick-extension` |
| Conductor | `http://github.com/gemini-cli-extensions/conductor` | `https://github.com/gemini-cli-extensions/conductor` |

### Why
- `galz10` was renamed to `galdawave` — GitHub redirects today, but the README should carry the canonical URL (verified via the REST API: the repo now resolves to `galdawave/pickle-rick-extension`)
- The remaining plain-`http` link upgraded to `https` for consistency with the rest of the list

### Verification
- `galdawave/pickle-rick-extension` confirmed live via `GET /repos/galdawave/pickle-rick-extension`
- No other `http://` links remain in the README

Follow-up to #113 (dead-link cleanup).