### PR TITLE
Add YYLO to Agent Orchestration & CLI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Modified versions of Gemini CLI with enhanced features or alternative model supp
 - [intentic](https://github.com/intentic/intentic) - Self-hosted workspace that runs Gemini CLI over ACP (`gemini --experimental-acp`) alongside Claude Code, Codex, and OpenCode. Each agent gets its own Docker container and git worktree on hardware you own; terminals survive disconnects, any browser or phone reopens the same fleet, and changes land through per-file, per-hunk diff review. Scheduled and webhook-triggered runs. MIT.
 - [SandBase CLI](https://github.com/sandbaseai/cli) - Open-source CLI and MCP bridge that configures Gemini CLI and other AI coding agents to access 2,000+ AI models and APIs through one account.
 - [godmode](https://github.com/arbazkhan971/godmode) - Discipline layer for AI coding agents: 135 skills and 7 subagents that wrap Gemini CLI (and Claude Code, Codex, Cursor, OpenCode, Amp, and pi) in a measure → modify → verify → keep/revert loop with automatic rollback of failed changes. MIT.
+- [YYLO](https://github.com/yylo-dev/yylo) - Kanban-driven CLI orchestrator that runs Gemini CLI alongside Claude Code and Codex in parallel across isolated git worktrees, with a merge queue that reviews and merges verified task work. Git-native task state, per-agent worktree isolation, installable via npm. MIT.
 
 ## Commands & Extensions
 


### PR DESCRIPTION
[YYLO](https://github.com/yylo-dev/yylo) is a kanban-driven CLI orchestrator that runs coding agents in parallel across isolated git worktrees. It dispatches Gemini CLI tasks alongside Claude Code and Codex from a Kanban board stored in git, gives each task its own worktree so agents never trample each other, and lands finished work through a merge queue that reviews and merges verified task commits. It fits Agent Orchestration & CLI Tools next to Bernstein, Parallel Code and AgentBox; I added it at the bottom of the section in the `- [Name](URL) - Description` format.

Install: `npm i -g @yylo/cli`. Repo: MIT licensed, actively developed since January 2026 (daily pushes), 56★.

Full disclosure: I maintain this project.